### PR TITLE
Update Show Careers on Equipped Items.lua

### DIFF
--- a/scripts/mods/Show Careers on Equipped Items/Show Careers on Equipped Items.lua
+++ b/scripts/mods/Show Careers on Equipped Items/Show Careers on Equipped Items.lua
@@ -18,8 +18,10 @@ CareerNameMappings = {
 	we_shade = {name = "Shade", index = 4},
 	bw_unchained = {name = "Unchained", index = 2},
 	bw_scholar = {name = "Pyromancer", index = 2},
-    wh_bountyhunter = {name = "Bounty Hunter", index = 1},
-    es_questingknight = {name = "Grail Knight", index = 5},
+    	wh_bountyhunter = {name = "Bounty Hunter", index = 1},
+    	es_questingknight = {name = "Grail Knight", index = 5},
+	we_thornsister = {name = "Sister of the Thorn", index = 4},
+	dr_engineer = {name = "Outcast Engineer", index = 3},
 }
 
 local function get_career_names(backend_id)


### PR DESCRIPTION
Added Sister of the Thorn Career for Kerillian, and Outcast Engineer for Bardin. I will add the new career for Viktor when it comes out if you want to pull this and do a new build for Steam. I've seen a few mods get sanctioned lately so fingers crossed!

Built a version and overwrote the installed one and everything looks good.

![carreers](https://user-images.githubusercontent.com/1154391/144324624-b90b929a-7bab-4e2f-b5f2-6f18b85d87f7.png)


